### PR TITLE
Add github actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  release:
+    types: [published]
+  check_suite:
+    types: [rerequested]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: install deps
+      run: sudo apt install vice cc65
+
+    - name: build CCGMS
+      run: |
+        make -j$(nproc)
+        c1541 -format ccgms,fu d64 ccgms.d64 -write build/ccgmsterm.prg
+        make clean
+
+    - name: build CCGMS (EASYFLASH version)
+      run: |
+        make -j$(nproc) EASYFLASH=1
+        c1541 -format ccgms-easyflash,fu d64 ccgms-easyflash.d64 -write build/ccgmsterm.prg
+        make clean
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: artifacts
+        path: |
+          *.d64
+
+    - name: Create release                                                      
+      if: startsWith(github.ref, 'refs/tags/')                                  
+      uses: softprops/action-gh-release@v1                                      
+      with:                                                                     
+        files: |
+          *.d64
+        fail_on_unmatched_files: true
+        body: "Automatically created release"                                                                            


### PR DESCRIPTION
This will
 * produce a .d64 of both the regular and easyflash versions
 * if a release is tagged, it will add the .d64 files to the release automatically

Typical 'artifacts.zip' from a CI run (push, pull request):
![image](https://user-images.githubusercontent.com/1517291/155826372-3f8c55c0-4db2-4501-a993-160038fecf8f.png)

Typical release with auto-attached artifacts: https://github.com/jepler/ccgmsterm/releases/tag/testrelease-0
![image](https://user-images.githubusercontent.com/1517291/155826387-70dc4094-8c59-4e6a-93b9-fcd6536da6c5.png)
