### PR TITLE
Optionally compress with exomizer; the CI's will use it.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,13 @@ jobs:
 
     - name: build CCGMS
       run: |
-        make -j$(nproc)
-        c1541 -format ccgms,fu d64 ccgms.d64 -write build/ccgmsterm.prg
-        make clean
+        make -j$(nproc) EXOMIZER=1
+        cp build/disk.d64 ccgms.d64
 
     - name: build CCGMS (EASYFLASH version)
       run: |
-        make -j$(nproc) EASYFLASH=1
-        c1541 -format ccgms-easyflash,fu d64 ccgms-easyflash.d64 -write build/ccgmsterm.prg
-        make clean
+        make -j$(nproc) EASYFLASH=1 EXOMIZER=1
+        cp build/disk.d64 ccgms-exo.d64
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,29 +18,29 @@ jobs:
         submodules: true
 
     - name: install deps
-      run: sudo apt install vice cc65
+      run: sudo apt install cc65
 
     - name: build CCGMS
       run: |
         make -j$(nproc) EXOMIZER=1
-        cp build/disk.d64 ccgms.d64
+        cp build/ccgmsterm-exo.prg ccgms.prg
 
     - name: build CCGMS (EASYFLASH version)
       run: |
         make -j$(nproc) EASYFLASH=1 EXOMIZER=1
-        cp build/disk.d64 ccgms-exo.d64
+        cp build/ccgmsterm-exo.prg ccgms-ezflash.prg
 
     - uses: actions/upload-artifact@v2
       with:
         name: artifacts
         path: |
-          *.d64
+          *.prg
 
     - name: Create release                                                      
       if: startsWith(github.ref, 'refs/tags/')                                  
       uses: softprops/action-gh-release@v1                                      
       with:                                                                     
         files: |
-          *.d64
+          *.prg
         fail_on_unmatched_files: true
         body: "Automatically created release"                                                                            

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  release:
+    types: [published]
+  check_suite:
+    types: [rerequested]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: install deps
+      run: sudo apt install vice cc65
+
+    - name: build CCGMS
+      run: |
+        make -j$(nproc)
+        c1541 -format ccgms,fu d64 ccgms.d64 -write build/ccgmsterm.prg
+        make clean
+
+    - name: build CCGMS (EASYFLASH version)
+      run: |
+        make -j$(nproc) EASYFLASH=1
+        c1541 -format ccgms-easyflash,fu d64 ccgms-easyflash.d64 -write build/ccgmsterm.prg
+        make clean
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: artifacts
+        path: |
+          *.d64
+
+    - name: Create release                                                      
+      if: startsWith(github.ref, 'refs/tags/')                                  
+      uses: softprops/action-gh-release@v1                                      
+      with:                                                                     
+        files: |
+          *.d64
+        fail_on_unmatched_files: true
+        body: "Automatically created release"                                                                            

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.map
 *.sym
 *.prg
+*.d64
 build

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "exomizer"]
+	path = exomizer
+	url = https://bitbucket.org/magli143/exomizer/

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,13 @@ export PATH:=$(abspath bin):$(PATH)
 EASYFLASH ?= 0
 EXOMIZER ?= 0
 
-ifeq ($(EXOMIZER),1)
-	EXO_PATH := build/bin/exomizer
-	EXO_ARGS := sfx sys -q -n -T4 -M256 -Di_perf=2
-else
-	EXO_PATH :=
-endif
+EXO_PATH := build/bin/exomizer
+EXO_ARGS := sfx sys -q -n -T4 -M256 -Di_perf=2
 
-ifeq ($(EASYFLASH),0)
-LABEL = ccgms
+ifeq ($(EXOMIZER),1)
+RUN_PRG = build/ccgmsterm-exo.prg
 else
-LABEL = ccgms-ezflash
+RUN_PRG = build/ccgmsterm.prg
 endif
 
 .PHONY: all
@@ -22,9 +18,6 @@ all: $(EXO_PATH)
 	cl65 -g -C src/ccgmsterm.cfg build/ccgmsterm.o -o build/ccgmsterm.prg -Ln build/ccgmsterm.sym -m build/ccgmsterm.map
 ifeq ($(EXOMIZER),1)
 	$(EXO_PATH) $(EXO_ARGS) -o build/ccgmsterm-exo.prg build/ccgmsterm.prg
-	c1541 -format $(LABEL),fu d64 build/disk.d64 -write build/ccgmsterm-exo.prg ccgms
-else
-	c1541 -format $(LABEL),fu d64 build/disk.d64 -write build/ccgmsterm.prg ccgms
 endif
 
 $(EXO_PATH):
@@ -35,7 +28,7 @@ $(EXO_PATH):
 
 .PHONY: run
 run: all
-	x64sc +cart -acia1 -acia1base 0xDE00 -acia1irq 1 -acia1mode 1 -myaciadev 0 -rsdev1 localhost:25232 -rsdev1baud 9600 build/disk.d64
+	x64sc -silent -autostartprgmode 1 +cart -acia1 -acia1base 0xDE00 -acia1irq 1 -acia1mode 1 -myaciadev 0 -rsdev1 localhost:25232 -rsdev1baud 9600 $(RUN_PRG)
 
 .PHONY: usb
 usb: all

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,46 @@
+export PATH:=$(abspath bin):$(PATH)
 EASYFLASH ?= 0
+EXOMIZER ?= 0
 
-all:
+ifeq ($(EXOMIZER),1)
+	EXO_PATH := build/bin/exomizer
+	EXO_ARGS := sfx sys -q -n -T4 -M256 -Di_perf=2
+else
+	EXO_PATH :=
+endif
+
+ifeq ($(EASYFLASH),0)
+LABEL = ccgms
+else
+LABEL = ccgms-ezflash
+endif
+
+.PHONY: all
+all: $(EXO_PATH)
 	mkdir -p build
 	ca65 -g src/ccgmsterm.s -o build/ccgmsterm.o -DEASYFLASH=$(EASYFLASH)
 	cl65 -g -C src/ccgmsterm.cfg build/ccgmsterm.o -o build/ccgmsterm.prg -Ln build/ccgmsterm.sym -m build/ccgmsterm.map
+ifeq ($(EXOMIZER),1)
+	$(EXO_PATH) $(EXO_ARGS) -o build/ccgmsterm-exo.prg build/ccgmsterm.prg
+	c1541 -format $(LABEL),fu d64 build/disk.d64 -write build/ccgmsterm-exo.prg ccgms
+else
+	c1541 -format $(LABEL),fu d64 build/disk.d64 -write build/ccgmsterm.prg ccgms
+endif
 
+$(EXO_PATH):
+	[ -d exomizer/src ] || git submodule update --init exomizer
+	mkdir -p build/bin
+	$(MAKE) -C exomizer/src CFLAGS="-Wall -Wstrict-prototypes -pedantic -O3"
+	cp exomizer/src/exomizer build/bin
 
+.PHONY: run
 run: all
-	c1541 -format ccgms,fu d64 build/disk.d64 -write build/ccgmsterm.prg
 	x64sc +cart -acia1 -acia1base 0xDE00 -acia1irq 1 -acia1mode 1 -myaciadev 0 -rsdev1 localhost:25232 -rsdev1baud 9600 build/disk.d64
 
+.PHONY: usb
 usb: all
 	cp build/ccgmsterm.prg /Volumes/C64/; diskutil unmountDisk force /Volumes/C64
 
+.PHONY: clean
 clean:
 	rm -rf build


### PR DESCRIPTION
Compressed from 23035 -> 13307 bytes (-42%) in my testing.

This is cumulative with the Actions PR (#8).